### PR TITLE
🔨 Fix SCSS hot reload

### DIFF
--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -25,7 +25,7 @@ const build = gulp.series(sass, eleventy.build);
 const develop = gulp.series(
   sass,
   gulp.parallel(() => {
-    gulp.watch('./styles/bento-dev.scss', sass);
+    gulp.watch('./styles/**/*.scss', sass);
   }, eleventy.develop)
 );
 

--- a/transforms/insertStyles.js
+++ b/transforms/insertStyles.js
@@ -26,7 +26,7 @@ async function insertStyles(content, outputPath) {
     return content;
   }
 
-  const css = await fs.readFile('./styles/bento-dev.css', {
+  const css = await fs.readFile('./assets/css/bento-dev.css', {
     encoding: 'utf-8',
   });
 


### PR DESCRIPTION
Gulp was only watching for changes in the main SCSS file.