### PR TITLE
🔧 Explicitly ignore amphtml during lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 node_modules
 dist
 build
-
-amphtml
+amphtml/**/*

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "eleventy",
     "develop": "npx gulp develop",
-    "lint": "eslint **/*.js",
-    "lint:fix": "eslint **/*.js --fix",
+    "lint": "eslint ./*.js -c ./.eslintrc.json --ignore-pattern amphtml",
+    "lint:fix": "eslint **/*.js -c ./.eslintrc.json --ignore-pattern amphtml --fix",
     "serve": "eleventy --serve",
     "start": "npx gulp --tasks",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Without this eslint continuously tries to do things with the amphtml submodule:

```
 ~/P/www-bento-dev   main      npm run lint -- --fix                         1571ms  Di  5 Okt 13:43:29 2021

> bento-dev@1.0.0 lint /Users/matthias.rohmer/Projects/www-bento-dev
> eslint **/*.js "--fix"


Oops! Something went wrong! :(

ESLint: 7.32.0

Error: Cannot read config file: /Users/matthias.rohmer/Projects/www-bento-dev/amphtml/.eslintrc.js
Error: ENOENT: no such file or directory, open 'build-system/global-configs/experiments-const.json'
    at Object.openSync (fs.js:498:3)
```