### PR TITLE
✨ Implement example embeds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,9 +5,12 @@ const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const toc = require('eleventy-plugin-toc');
 
 const noOpShortCode = require('./shortcodes/NoOp.js');
+const { exampleShortCode, writeExamples } = require('./shortcodes/Example.js');
+
 const insertStyles = require('./transforms/insertStyles.js');
 
 const isProduction = process.env.NODE_ENV === 'production';
+global.__basedir = __dirname;
 
 module.exports = (eleventyConfig) => {
   eleventyConfig.setUseGitIgnore(false);
@@ -16,18 +19,23 @@ module.exports = (eleventyConfig) => {
   eleventyConfig.addPassthroughCopy('assets');
   eleventyConfig.addWatchTarget('./assets/**/*.css');
 
-  eleventyConfig.addPairedShortcode('tip', noOpShortCode);
-
-  eleventyConfig.setLibrary('md', markdownIt().use(markdownItAnchor));
+  eleventyConfig.setLibrary('md', markdownIt({
+    html: true
+  }).use(markdownItAnchor).disable('code'));
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPlugin(toc);
 
+  eleventyConfig.addPairedShortcode('tip', noOpShortCode);
+  eleventyConfig.addNunjucksTag('examples', exampleShortCode);
+
   eleventyConfig.addTransform('insert-styles', insertStyles);
 
+  eleventyConfig.on('afterBuild', writeExamples);
+
   return {
-    markdownTemplateEngine: 'njk',
-    dataTemplateEngine: 'njk',
+    templateFormats: ['njk', 'md'],
     htmlTemplateEngine: 'njk',
+    markdownTemplateEngine: 'njk',
     dir: {
       input: 'site',
       output: 'dist',

--- a/assets/iframes/.gitkeep
+++ b/assets/iframes/.gitkeep
@@ -1,0 +1,2 @@
+# This file is here to automatically create an
+# iframe directory both here and later in `dist`

--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -99,6 +99,10 @@ function _escapeVariables(contents) {
   });
 }
 
+function _rewriteCodeFenceShToBash(contents) {
+  return contents.replace(/```sh/gm, '```bash');
+}
+
 function _parseComponentName(content) {
   const matches = /# (Bento .+)/gm.exec(content);
   return matches[1];

--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -99,7 +99,7 @@ function _escapeVariables(contents) {
 }
 
 function _rewriteCodeFenceShToBash(contents) {
-  return contents.replace(/```sh/gm, '```bash');
+  return contents.replace(/```bash(\s.*?\s)```/gm, '```bash$1```');
 }
 
 function _parseComponentName(content) {

--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -41,8 +41,7 @@ function _rewriteCalloutToTip(contents) {
 }
 
 function _rewriteExamples(contents) {
-  const EXAMPLE_PATTERN =
-    /\[example (.*?)\](.*?)\[\/example\]/gs;
+  const EXAMPLE_PATTERN = /\[example (.*?)\](.*?)\[\/example\]/gs;
 
   contents = contents.replace(EXAMPLE_PATTERN, (match, args, example) => {
     return `{% example %}${example}{% endexample %}`;
@@ -135,6 +134,7 @@ async function importComponents() {
         document.content = _rewriteCalloutToTip(document.content);
         document.content = _escapeVariables(document.content);
         document.content = _rewriteExamples(document.content);
+        document.content = _rewriteCodeFenceShToBash(document.content);
 
         await fs.writeFile(
           path.join(COMPONENTS_DEST, `${fileName}.md`),

--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -64,10 +64,10 @@ function _escapeVariables(contents) {
   // or we add raw tags to existing raw blocks
   const MARKDOWN_BLOCK_PATTERN = new RegExp(
     JINJA2_RAW_BLOCK.source +
-    '|' +
-    SOURCECODE_BLOCK.source +
-    '|' +
-    /`[^`]*`/.source,
+      '|' +
+      SOURCECODE_BLOCK.source +
+      '|' +
+      /`[^`]*`/.source,
     'g'
   );
 
@@ -76,10 +76,10 @@ function _escapeVariables(contents) {
   // TODO: Avoid the need to distinguish between mustache and jinja2
   const MUSTACHE_PATTERN = new RegExp(
     '(' +
-    JINJA2_RAW_BLOCK.source +
-    '|' +
-    /\{\{(?!\s*server_for_email\s*\}\})(?:[\s\S]*?\}\})?/.source +
-    ')',
+      JINJA2_RAW_BLOCK.source +
+      '|' +
+      /\{\{(?!\s*server_for_email\s*\}\})(?:[\s\S]*?\}\})?/.source +
+      ')',
     'g'
   );
 

--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -40,6 +40,17 @@ function _rewriteCalloutToTip(contents) {
   return contents;
 }
 
+function _rewriteExamples(contents) {
+  const EXAMPLE_PATTERN =
+    /\[example (.*?)\](.*?)\[\/example\]/gs;
+
+  contents = contents.replace(EXAMPLE_PATTERN, (match, args, example) => {
+    return `{% example %}${example}{% endexample %}`;
+  });
+
+  return contents;
+}
+
 function _escapeVariables(contents) {
   // This expression matches a {% raw %}...{% endraw %} block
   const JINJA2_RAW_BLOCK =
@@ -54,10 +65,10 @@ function _escapeVariables(contents) {
   // or we add raw tags to existing raw blocks
   const MARKDOWN_BLOCK_PATTERN = new RegExp(
     JINJA2_RAW_BLOCK.source +
-      '|' +
-      SOURCECODE_BLOCK.source +
-      '|' +
-      /`[^`]*`/.source,
+    '|' +
+    SOURCECODE_BLOCK.source +
+    '|' +
+    /`[^`]*`/.source,
     'g'
   );
 
@@ -66,10 +77,10 @@ function _escapeVariables(contents) {
   // TODO: Avoid the need to distinguish between mustache and jinja2
   const MUSTACHE_PATTERN = new RegExp(
     '(' +
-      JINJA2_RAW_BLOCK.source +
-      '|' +
-      /\{\{(?!\s*server_for_email\s*\}\})(?:[\s\S]*?\}\})?/.source +
-      ')',
+    JINJA2_RAW_BLOCK.source +
+    '|' +
+    /\{\{(?!\s*server_for_email\s*\}\})(?:[\s\S]*?\}\})?/.source +
+    ')',
     'g'
   );
 
@@ -119,6 +130,7 @@ async function importComponents() {
 
         document.content = _rewriteCalloutToTip(document.content);
         document.content = _escapeVariables(document.content);
+        document.content = _rewriteExamples(document.content);
 
         await fs.writeFile(
           path.join(COMPONENTS_DEST, `${fileName}.md`),

--- a/shortcodes/Example.js
+++ b/shortcodes/Example.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const Prism = require('prismjs');
+const md = require('markdown-it')();
+
+const examples = [];
+const heads = {};
+let counter = {};
+
+function exampleShortCode(nunjucksEngine) {
+  return new function () {
+    this.tags = ['example'];
+
+    this.parse = function (parser, nodes, lexer) {
+      let tok = parser.nextToken();
+
+      let args = parser.parseSignature(null, true);
+      parser.advanceAfterBlockEnd(tok.value);
+
+      let body = parser.parseUntilBlocks('endexample');
+      parser.advanceAfterBlockEnd();
+
+      return new nodes.CallExtensionAsync(this, 'run', args, [body]);
+    };
+
+    this._parseContents = function (contents) {
+      const HTML_CODE_PATTERN = /```html\n(.*?)\n```/gms;
+      const html = {
+        all: HTML_CODE_PATTERN.exec(contents)
+      };
+      html.all = html.all && html.all[1] ? html.all[1] : undefined;
+
+      if (!html.all) {
+        // We only support HTML examples. If the example doesn't
+        // contain HTML, simply return
+        return {};
+      }
+
+      const HTML_HEAD_PATTERN = /<head>(.*?)<\/head>/gms;
+      html.head = HTML_HEAD_PATTERN.exec(html.all);
+      html.head = html.head && html.head[1] ? html.head[1] : undefined;
+
+      const HTML_BODY_PATTERN = /<body>(.*?)<\/body>/gms;
+      html.body = HTML_BODY_PATTERN.exec(html.all);
+      html.body = html.body && html.body[1] ? html.body[1] : undefined;
+
+      // If there is no body, take all of the HTML, but discard the head
+      html.body = html.all.replace(HTML_HEAD_PATTERN, '');
+
+      // Check if there is dedicated CSS code that needs to be merged
+      // into the head
+      const CSS_CODE_PATTERN = /```css\n(.*?)\n```/gms;
+      html.css = CSS_CODE_PATTERN.exec(contents);
+      html.css = html.css && html.css[1] ? html.css[1] : undefined;
+
+      return html;
+    }
+
+    this.run = function (context, contents, callback) {
+      // Build a reusable ID for file names and radio buttons
+      const ctx = context.ctx;
+      counter[ctx.page.fileSlug] = counter[ctx.page.fileSlug] + 1 || 0;
+      const id = `${ctx.page.fileSlug}-${counter[ctx.page.fileSlug]}`;
+
+      const html = this._parseContents(contents());
+      // Verify the parsed HTML includes a HTML snippet, otherwise
+      // do not generate an iframe
+      let iframe;
+      if (html.all) {
+        iframe = nunjucksEngine.render('site/_includes/layouts/example.njk', { id, html, title: ctx.title });
+        examples.push({ id, iframe });
+      }
+
+      let widget = contents();
+      if (html.all) {
+        widget = nunjucksEngine.render(
+          'site/_includes/partials/example.njk',
+          { id, source: contents(), iframe: !!iframe, title: ctx.title }
+        );
+      }
+
+      callback(null, nunjucksEngine.runtime.markSafe(widget));
+    }
+  };
+}
+
+async function writeExamples() {
+  console.log('Writing examples ...');
+  await Promise.all(examples.map((example) => {
+    return fs.writeFile(path.join(`${global.__basedir}/dist/assets/iframes`, `${example.id}.html`), example.iframe);
+  })).then(() => {
+    counter = {};
+    console.log('Wrote examples!');
+  })
+}
+
+module.exports = {
+  exampleShortCode,
+  writeExamples
+};

--- a/shortcodes/Example.js
+++ b/shortcodes/Example.js
@@ -55,6 +55,9 @@ function exampleShortCode(nunjucksEngine) {
       const HTML_HEAD_PATTERN = /<head>(.*?)<\/head>/gms;
       html.head = HTML_HEAD_PATTERN.exec(html.all);
       html.head = html.head && html.head[1] ? html.head[1] : undefined;
+      if (!html.head) {
+        return {};
+      }
 
       const HTML_BODY_PATTERN = /<body>(.*?)<\/body>/gms;
       html.body = HTML_BODY_PATTERN.exec(html.all);
@@ -62,12 +65,6 @@ function exampleShortCode(nunjucksEngine) {
 
       // If there is no body, take all of the HTML, but discard the head
       html.body = html.all.replace(HTML_HEAD_PATTERN, '');
-
-      // Check if there is dedicated CSS code that needs to be merged
-      // into the head
-      const CSS_CODE_PATTERN = /```css\n(.*?)\n```/gms;
-      html.css = CSS_CODE_PATTERN.exec(contents);
-      html.css = html.css && html.css[1] ? html.css[1] : undefined;
 
       return html;
     }
@@ -79,16 +76,15 @@ function exampleShortCode(nunjucksEngine) {
       const id = `${ctx.page.fileSlug}-${counter[ctx.page.fileSlug]}`;
 
       const html = this._parseContents(contents());
-      // Verify the parsed HTML includes a HTML snippet, otherwise
-      // do not generate an iframe
+
       let iframe;
-      if (html.all) {
+      if (html.head && html.body) {
         iframe = nunjucksEngine.render('site/_includes/layouts/example.njk', { id, html, title: ctx.title });
         examples.push({ id, iframe });
       }
 
       let widget = contents();
-      if (html.all) {
+      if (html.head && html.body) {
         widget = nunjucksEngine.render(
           'site/_includes/partials/example.njk',
           { id, source: contents(), iframe: !!iframe, title: ctx.title }

--- a/shortcodes/Example.js
+++ b/shortcodes/Example.js
@@ -20,7 +20,6 @@ const Prism = require('prismjs');
 const md = require('markdown-it')();
 
 const examples = [];
-const heads = {};
 let counter = {};
 
 function exampleShortCode(nunjucksEngine) {

--- a/site/_includes/layouts/example.njk
+++ b/site/_includes/layouts/example.njk
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>bento.dev Example: {{ title }}</title>
+    <title>bentojs.dev Example: {{ title }}</title>
     <meta name="robots" content="noindex"> 
     {{ html.head|safe }}
     {% if html.css %}

--- a/site/_includes/layouts/example.njk
+++ b/site/_includes/layouts/example.njk
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>bento.dev Example: {{ title }}</title>
+    <meta name="robots" content="noindex"> 
+    {{ html.head|safe }}
+    {% if html.css %}
+    <style>
+      {{ html.css|safe }}
+    </style>
+    {% endif %}
+  </head>
+  <body>
+    {{ html.body|safe }}
+  </body>
+</html>

--- a/site/_includes/partials/example.njk
+++ b/site/_includes/partials/example.njk
@@ -1,0 +1,22 @@
+{# Caution, this file is exactly idented as it needs to be.
+Do not change formatting this would break rendering. #}
+
+<section class="bd-example">
+<header class="bd-example-toggle">
+{% if iframe %}
+<input type="radio" name="{{ id }}" value="code" checked>
+<label for="{{ id }}-code">Code</label>
+<input type="radio" name="{{ id }}" value="preview">
+<label for="{{ id }}-preview">Preview</label>
+{% endif %}
+</header>
+<div class="bd-example-code">
+{{ source|safe }}
+</div>
+
+{% if iframe %}
+<div class="bd-example-preview">
+<iframe src="/assets/iframes/{{ id }}.html"></iframe>
+</div>
+{% endif %}
+</section>

--- a/site/en/components/bento-accordion.md
+++ b/site/en/components/bento-accordion.md
@@ -34,7 +34,7 @@ The examples below demonstrate use of the `<bento-accordion>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -46,14 +46,14 @@ npm install @ampproject/bento-accordion
 import '@ampproject/bento-accordion';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
 The example below contains an `bento-accordion` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -91,7 +91,7 @@ The example below contains an `bento-accordion` with three sections. The
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 
@@ -292,7 +292,7 @@ animation when the content is expanded and "roll up" animation when collapsed.
 
 This attribute can be configured to based on a [media query](./../../../docs/spec/amp-html-responsive-attributes.md).
 
-[example preview="top-frame" playground="true" imports="bento-accordion:1.0"]
+{% example %}
 
 ```html
 <bento-accordion animate>
@@ -311,13 +311,13 @@ This attribute can be configured to based on a [media query](./../../../docs/spe
 </bento-accordion>
 ```
 
-[/example]
+{% endexample %}
 
 ##### expanded
 
 Apply the `expanded` attribute to a nested `<section>` to expand that section when the page loads.
 
-[example preview="top-frame" playground="true" imports="bento-accordion:1.0"]
+{% example %}
 
 ```html
 <bento-accordion>
@@ -336,13 +336,13 @@ Apply the `expanded` attribute to a nested `<section>` to expand that section wh
 </bento-accordion>
 ```
 
-[/example]
+{% endexample %}
 
 ##### expand-single-section
 
 Allow only one section to expand at a time by applying the `expand-single-section` attribute to the `<bento-accordion>` element. This means if a user taps on a collapsed `<section>`, it will expand and collapse other expanded `<section>`'s.
 
-[example preview="top-frame" playground="true" imports="bento-accordion:1.0"]
+{% example %}
 
 ```html
 <bento-accordion expand-single-section>
@@ -365,7 +365,7 @@ Allow only one section to expand at a time by applying the `expand-single-sectio
 </bento-accordion>
 ```
 
-[/example]
+{% endexample %}
 
 #### Styling
 
@@ -390,7 +390,7 @@ The examples below demonstrates use of the `<BentoAccordion>` as a functional co
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -425,7 +425,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 

--- a/site/en/components/bento-carousel.md
+++ b/site/en/components/bento-carousel.md
@@ -26,7 +26,7 @@ The examples below demonstrate use of the `<bento-base-carousel>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -38,11 +38,11 @@ npm install @ampproject/bento-base-carousel
 import '@ampproject/bento-base-carousel';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -102,7 +102,7 @@ import '@ampproject/bento-base-carousel';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 
@@ -390,7 +390,7 @@ The examples below demonstrate use of the `<BentoBaseCarousel>` as a functional 
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -414,7 +414,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 

--- a/site/en/components/bento-date-countdown.md
+++ b/site/en/components/bento-date-countdown.md
@@ -17,7 +17,7 @@ The examples below demonstrate use of the `<bento-date-countdown>` web component
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -29,14 +29,14 @@ npm install @ampproject/bento-date-countdown
 import '@ampproject/bento-date-countdown';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
 The example below contains an `bento-date-countdown` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -61,7 +61,7 @@ The example below contains an `bento-date-countdown` with three sections. The
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 
@@ -172,7 +172,7 @@ The examples below demonstrates use of the `<BentoDateCountdown>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -206,7 +206,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 

--- a/site/en/components/bento-date-display.md
+++ b/site/en/components/bento-date-display.md
@@ -22,7 +22,7 @@ The examples below demonstrate use of the `<bento-date-display>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -34,14 +34,14 @@ npm install @ampproject/bento-date-display
 import '@ampproject/bento-date-display';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
 The example below contains an `bento-date-display` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -62,7 +62,7 @@ The example below contains an `bento-date-display` with three sections. The
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 
@@ -141,7 +141,7 @@ The examples below demonstrates use of the `<BentoDateDisplay>` as a functional 
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -168,7 +168,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 

--- a/site/en/components/bento-embedly-card.md
+++ b/site/en/components/bento-embedly-card.md
@@ -22,7 +22,7 @@ The examples below demonstrate use of the `<bento-embedly-card>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -34,11 +34,11 @@ npm install @ampproject/bento-embedly-card
 import '@ampproject/bento-embedly-card';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -93,7 +93,7 @@ import '@ampproject/bento-embedly-card';
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -189,7 +189,7 @@ The examples below demonstrate use of the `<BentoEmbedlyCard>` as a functional c
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -212,7 +212,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-facebook.md
+++ b/site/en/components/bento-facebook.md
@@ -21,7 +21,7 @@ You must include each Bento component's required CSS library before adding custo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -33,11 +33,11 @@ npm install @ampproject/bento-facebook
 import '@ampproject/bento-facebook';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -137,7 +137,7 @@ import '@ampproject/bento-facebook';
 </bento-facebook>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and Style
 
@@ -300,7 +300,7 @@ The examples below demonstrate use of the `<BentoFacebook>` as a functional comp
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -323,7 +323,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Props
 

--- a/site/en/components/bento-fit-text.md
+++ b/site/en/components/bento-fit-text.md
@@ -19,7 +19,7 @@ The examples below demonstrate use of the `<bento-fit-text>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -31,11 +31,11 @@ npm install @ampproject/bento-fit-text
 import '@ampproject/bento-fit-text';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -71,7 +71,7 @@ import '@ampproject/bento-fit-text';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Overflowing content
 
@@ -80,7 +80,7 @@ If the content of the `bento-fit-text` overflows the available space, even with 
 
 In the following example, we specified a `min-font-size` of `40`, and added more content inside the `bento-fit-text` element. This causes the content to exceed the size of its fixed block parent, so the text is truncated to fit the container.
 
-[example preview="inline" playground="true" imports="bento-fit-text:1.0"]
+{% example %}
 
 ```html
 <div style="width: 300px; height: 300px; background: #005AF0; color: #FFF;">
@@ -92,7 +92,7 @@ In the following example, we specified a `min-font-size` of `40`, and added more
 </div>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -150,7 +150,7 @@ The examples below demonstrate use of the `<BentoFitText>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -173,7 +173,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-iframe.md
+++ b/site/en/components/bento-iframe.md
@@ -19,7 +19,7 @@ The examples below demonstrate use of the `<bento-iframe>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -31,11 +31,11 @@ npm install @ampproject/bento-iframe
 import '@ampproject/bento-iframe';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -73,7 +73,7 @@ import '@ampproject/bento-iframe';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -149,7 +149,7 @@ The examples below demonstrates use of the `<BentoIframe>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -173,7 +173,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Props
 

--- a/site/en/components/bento-inline-gallery.md
+++ b/site/en/components/bento-inline-gallery.md
@@ -17,7 +17,7 @@ The examples below demonstrate use of the `<bento-inline-gallery>` web component
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -29,13 +29,13 @@ npm install @ampproject/bento-inline-gallery
 import '@ampproject/bento-inline-gallery';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
 The example below contains a `bento-inline-gallery` consisting of three slides with thumbnails and a pagination indicator.
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -58,7 +58,7 @@ The example below contains a `bento-inline-gallery` consisting of three slides w
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -122,7 +122,7 @@ The examples below demonstrates use of the `<BentoInlineGallery>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -149,7 +149,7 @@ function App() {
   }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-mathml.md
+++ b/site/en/components/bento-mathml.md
@@ -17,7 +17,7 @@ The examples below demonstrate use of the `<bento-mathml>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -29,14 +29,14 @@ npm install @ampproject/bento-mathml
 import '@ampproject/bento-mathml';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
 The example below contains an `bento-mathml` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -63,7 +63,7 @@ The example below contains an `bento-mathml` with three sections. The
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -109,7 +109,7 @@ The examples below demonstrates use of the `<BentoMathml>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -142,7 +142,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-sidebar.md
+++ b/site/en/components/bento-sidebar.md
@@ -19,7 +19,7 @@ The examples below demonstrate use of the `<bento-sidebar>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -31,11 +31,11 @@ npm install @ampproject/bento-sidebar
 import '@ampproject/bento-sidebar';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -78,7 +78,7 @@ import '@ampproject/bento-sidebar';
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Bento Toolbar
 
@@ -220,7 +220,7 @@ The examples below demonstrate use of the `<BentoSidebar>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -249,7 +249,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Bento Toolbar
 

--- a/site/en/components/bento-social-share.md
+++ b/site/en/components/bento-social-share.md
@@ -19,7 +19,7 @@ The examples below demonstrate use of the `<bento-social-share>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -31,11 +31,11 @@ npm install @ampproject/bento-social-share
 import '@ampproject/bento-social-share';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -84,7 +84,7 @@ import '@ampproject/bento-social-share';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -335,7 +335,7 @@ The examples below demonstrate use of the `<BentoSocialShare>` as a functional c
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -358,7 +358,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-soundcloud.md
+++ b/site/en/components/bento-soundcloud.md
@@ -17,7 +17,7 @@ The examples below demonstrate use of the `<bento-soundcloud>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -29,11 +29,11 @@ npm install @ampproject/bento-soundcloud
 import '@ampproject/bento-soundcloud';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -79,7 +79,7 @@ import '@ampproject/bento-soundcloud';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -145,7 +145,7 @@ The examples below demonstrate use of the `<BentoSoundcloud>` as a functional co
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -166,7 +166,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-stream-gallery.md
+++ b/site/en/components/bento-stream-gallery.md
@@ -20,7 +20,7 @@ The examples below demonstrate use of the `<bento-stream-gallery>` web component
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -32,14 +32,14 @@ npm install @ampproject/bento-stream-gallery
 import '@ampproject/bento-stream-gallery';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
 The example below contains an `bento-stream-gallery` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -75,7 +75,7 @@ The example below contains an `bento-stream-gallery` with three sections. The
 </body>
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 
@@ -221,7 +221,7 @@ The examples below demonstrates use of the `<BentoStreamGallery>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -249,7 +249,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Interactivity and API usage
 

--- a/site/en/components/bento-twitter.md
+++ b/site/en/components/bento-twitter.md
@@ -17,7 +17,7 @@ The examples below demonstrate use of the `<bento-twitter>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -29,11 +29,11 @@ npm install @ampproject/bento-twitter
 import '@ampproject/bento-twitter';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -76,7 +76,7 @@ import '@ampproject/bento-twitter';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -141,7 +141,7 @@ The examples below demonstrate use of the `<BentoTwitter>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -162,7 +162,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/en/components/bento-wordpress-embed.md
+++ b/site/en/components/bento-wordpress-embed.md
@@ -17,7 +17,7 @@ The examples below demonstrate use of the `<bento-wordpress-embed>` web componen
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -29,11 +29,11 @@ npm install @ampproject/bento-wordpress-embed
 import '@ampproject/bento-wordpress-embed';
 ```
 
-[/example]
+{% endexample %}
 
 #### Example: Include via `<script>`
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 ```html
 <head>
@@ -66,7 +66,7 @@ import '@ampproject/bento-wordpress-embed';
 </script>
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 
@@ -111,7 +111,7 @@ The examples below demonstrate use of the `<BentoWordPressEmbed>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
+{% example %}
 
 Install via npm:
 
@@ -132,7 +132,7 @@ function App() {
 }
 ```
 
-[/example]
+{% endexample %}
 
 #### Layout and style
 

--- a/site/examples.njk
+++ b/site/examples.njk
@@ -1,0 +1,8 @@
+---
+pagination:
+  data: collections.example
+  size: 1
+  alias: example
+permalink: "examples/{{ example.slug }}/index.html"
+---
+<h1>{{ example.title }}</h1>


### PR DESCRIPTION
Sorry for the delay, had multiple formatting/escaping/parsing issues that I didn't foresee. What's left: how do we want to deal with incomplete examples that only show a snippet but don't have a `<head>`? On amp.dev we use validator rules to add needed scripts but with bento that wouldn't work. Possible solutions I thought of:

1) Make all docs require at least one full example with a `<head>` that is automatically reused for all other examples on the page
2) Add frontmatter to the docs that describe needed resources and create the head automatically. Might possibly also make sense for a consolidated intro section as on amp.dev
3) Make docs authors require to define a head in a second, hidden code section

![Bildschirmfoto 2021-10-11 um 18 34 58](https://user-images.githubusercontent.com/12857772/136826122-990450d7-60e3-4dd8-8b1d-3c1097d0e238.png)